### PR TITLE
Hide unique clicks when non-newsletters are present in reports

### DIFF
--- a/app/components/lead-report/tables/email-metrics.js
+++ b/app/components/lead-report/tables/email-metrics.js
@@ -15,6 +15,12 @@ export default Component.extend({
     return true;
   }),
 
+  displayUniqueClicks: computed('sends.@each.send.isNewsletter', function() {
+    const sends = this.get('sends');
+    console.log(sends);
+    return sends.every(({ send }) => send.isNewsletter);
+  }),
+
   init() {
     this._super(...arguments);
     this.set('iframe', {

--- a/app/gql/queries/reports/line-items/email/metrics.graphql
+++ b/app/gql/queries/reports/line-items/email/metrics.graphql
@@ -11,11 +11,17 @@ query EmailLineItemReportMetrics($hash: String!, $sort: EmailLineItemMetricsRepo
           ...EmailSendMetricsFragment
         }
         sentDate
+        isNewsletter
       }
       identities
+      clicks
+      advertiserClickRate
     }
     totals {
       identities
+      sends
+      clicks
+      advertiserClickRate
       metrics {
         ...EmailSendMetricsFragment
       }

--- a/app/templates/components/lead-report/tables/email-metrics.hbs
+++ b/app/templates/components/lead-report/tables/email-metrics.hbs
@@ -6,7 +6,9 @@
       <th>Delivered {{lead-report/tables/sort-field key="metrics.delivered" sortBy=sortBy ascending=ascending reset=false}}</th>
     {{/if}}
     <th>Unique Opens {{lead-report/tables/sort-field key="metrics.uniqueOpens" sortBy=sortBy ascending=ascending reset=false}}</th>
-    <th>Unique Clicks {{lead-report/tables/sort-field key="metrics.uniqueClicks" sortBy=sortBy ascending=ascending reset=false}}</th>
+    {{#if displayUniqueClicks}}
+      <th>Unique Clicks {{lead-report/tables/sort-field key="metrics.uniqueClicks" sortBy=sortBy ascending=ascending reset=false}}</th>
+    {{/if}}
     <th>Open Rate</th>
     <th>CTOR</th>
     <th>CTR</th>
@@ -30,7 +32,9 @@
         <td>{{ format-number row.send.metrics.delivered format="0,0" }}</td>
       {{/if}}
       <td>{{ format-number row.send.metrics.uniqueOpens format="0,0" }}</td>
-      <td>{{ format-number row.send.metrics.uniqueClicks format="0,0" }}</td>
+      {{#if displayUniqueClicks}}
+        <td>{{ format-number row.send.metrics.uniqueClicks format="0,0" }}</td>
+      {{/if}}
       <td>{{ format-number row.send.metrics.openRate format="00.0%" }}</td>
       <td>{{ format-number row.send.metrics.clickToOpenRate format="00.0%" }}</td>
       <td>{{ format-number row.send.metrics.clickToDeliveredRate format="00.0%" }}</td>
@@ -48,7 +52,9 @@
       <th>{{ format-number totals.metrics.delivered format="0,0" }}</th>
     {{/if}}
     <th>{{ format-number totals.metrics.uniqueOpens format="0,0" }}</th>
-    <th>{{ format-number totals.metrics.uniqueClicks format="0,0" }}</th>
+    {{#if displayUniqueClicks}}
+      <th>{{ format-number totals.metrics.uniqueClicks format="0,0" }}</th>
+    {{/if}}
     <th>{{ format-number totals.metrics.openRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToOpenRate format="00.0%" }}</th>
     <th>{{ format-number totals.metrics.clickToDeliveredRate format="00.0%" }}</th>


### PR DESCRIPTION
And ensure line item reports display individual clicks, advertiser CTR and totals.

Requires parameter1/leads-graph#72 to be merged and deployed first.